### PR TITLE
Add chart timer uptime data

### DIFF
--- a/src/gui/viewmodels/song.py
+++ b/src/gui/viewmodels/song.py
@@ -101,7 +101,7 @@ class SongView:
         self.widget.setSortingEnabled(True)
         for r_idx, card_data in enumerate(data):
             for c_idx, (key, value) in enumerate(card_data.items()):
-                if isinstance(value, int) and 13 >= c_idx >= 7 or c_idx == 1:
+                if isinstance(value, int) and 21 >= c_idx >= 7 or c_idx == 1:
                     item = NumericalTableWidgetItem(value)
                 elif value is None:
                     item = QTableWidgetItem("")

--- a/src/gui/viewmodels/song.py
+++ b/src/gui/viewmodels/song.py
@@ -68,7 +68,7 @@ class SongView:
         self.widget.setSelectionMode(QAbstractItemView.SingleSelection)
         self.widget.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.widget.setToolTip("Right click to toggle note types between number and percentage.\n"
-                               "Shift-right click to toggle timer percentages")
+                               "Shift-right click to toggle timer percentages.")
         self.model = False
         self.percentage = False
         self.timers = False

--- a/src/logic/live.py
+++ b/src/logic/live.py
@@ -37,6 +37,13 @@ def classify_note(row):
         return NoteType.SLIDE
 
 
+def classify_note_vectorized(row):
+    return np.choose(row.type - 3, [
+        np.choose(row.status == 0, [NoteType.FLICK, np.choose(
+            row.type - 1, [NoteType.TAP, NoteType.LONG, NoteType.SLIDE], mode="clip")]),
+        NoteType.TAP, NoteType.SLIDE, NoteType.FLICK, NoteType.FLICK], mode="clip")
+
+
 def get_score_color(score_id):
     color = db.masterdb.execute_and_fetchall("SELECT live_data.type FROM live_data WHERE live_data.id = ?",
                                              [score_id])

--- a/src/logic/skill.py
+++ b/src/logic/skill.py
@@ -12,6 +12,8 @@ COLOR_TARGETS = {21, 22, 23, 32, 33, 34}
 ACT_TYPES = {28: NoteType.LONG, 29: NoteType.FLICK, 30: NoteType.SLIDE}
 SUPPORT_TYPES = {5, 6, 7}
 COMBO_SUPPORT_TYPES = {9, 14}
+COMMON_TIMERS = [(7, 4.5, 'h'), (9, 6, 'h'), (11, 7.5, 'h'), (12, 7.5, 'm'),
+                 (6, 4.5, 'm'), (9, 7.5, 'm'), (11, 9, 'm'), (13, 9, 'h')]
 
 
 class Skill:

--- a/src/network/chart_cache_updater.py
+++ b/src/network/chart_cache_updater.py
@@ -10,8 +10,10 @@ import requests
 import customlogger as logger
 from db import db
 from logic.live import classify_note_vectorized
+from logic.skill import COMMON_TIMERS
 from network import meta_updater
 from settings import REMOTE_TRANSLATED_SONG_URL, REMOTE_CACHE_SCORES_URL, MUSICSCORES_PATH
+from static.live_values import WEIGHT_RANGE
 from static.note_type import NoteType
 
 BLACKLIST = "1901,1902,1903,1904,90001"
@@ -290,12 +292,8 @@ def _overwrite_song_name(expanded_song_list):
     db.cachedb.commit()
 
 
-timers = [(7, 4.5, 'h'), (9, 6, 'h'), (11, 7.5, 'h'), (12, 7.5, 'm'),
-          (6, 4.5, 'm'), (9, 7.5, 'm'), (11, 9, 'm'), (13, 9, 'h')]
-
-
-def is_active(time, period, duration, last_note):
-    return (time > period) & (time % period < duration) & (time // period * period <= last_note - 3)
+def _is_active(time, interval, duration, last_note):
+    return (time > interval) & (time % interval < duration) & (time // interval * interval <= last_note - 3)
 
 
 def update_cache_scores():
@@ -332,21 +330,14 @@ def update_cache_scores():
                 live_data[key_str] = 0
         live_data['difficulty'] = live_data['diff']
         total_notes = len(notes_data)
-        combo_thresholds = np.array([
-            1,
-            total_notes // 20,
-            total_notes // 10,
-            total_notes // 4,
-            total_notes // 2,
-            total_notes * 7 // 10,
-            total_notes * 8 // 10,
-            total_notes * 9 // 10,
-            total_notes + 1
-        ])
-        for timer in timers:
+        combo_thresholds = (total_notes * WEIGHT_RANGE[:, 0] / 100).astype(int)
+        # Correct for deresute's rounding method
+        combo_thresholds[1:-1] -= 1
+        for timer in COMMON_TIMERS:
             live_data['Timer_{}{}'.format(timer[0], timer[2])] = np.repeat(
-                [1., 1.1, 1.2, 1.3, 1.4, 1.5, 1.7, 2.], combo_thresholds[1:] - combo_thresholds[:-1]
-            )[is_active(notes_data['sec'], timer[0], timer[1], notes_data.iloc[-1]['sec'])].sum() / (1.41 * total_notes)
+                WEIGHT_RANGE[:, 1], combo_thresholds[1:] - combo_thresholds[:-1]
+            )[_is_active(notes_data['sec'], timer[0], timer[1], notes_data.iloc[-1]['sec'])].sum() / (
+                    ((WEIGHT_RANGE[1:, 0] - WEIGHT_RANGE[:-1, 0]) * WEIGHT_RANGE[:-1, 1]).sum() / 100 * total_notes)
         _insert_into_live_detail_cache(live_data)
     _overwrite_song_name(expanded_song_list)
     db.cachedb.commit()

--- a/test/test_classify_note.py
+++ b/test/test_classify_note.py
@@ -1,0 +1,40 @@
+import unittest
+from io import StringIO
+
+import pandas as pd
+
+from db import db
+from logic.live import classify_note, classify_note_vectorized
+from network.chart_cache_updater import _get_song_list, _expand_song_list
+from settings import MUSICSCORES_PATH
+import customlogger as logger
+
+
+class ClassifyNote(unittest.TestCase):
+    def test_classify_note(self):
+        song_list = _get_song_list()
+        expanded_song_list = _expand_song_list(song_list)
+        live_detail_ids = {_[0] for _ in
+                                  db.cachedb.execute_and_fetchall("SELECT live_detail_id FROM live_detail_cache")}
+        for ldid in live_detail_ids:
+            live_data = expanded_song_list[ldid]
+            with db.CustomDB(MUSICSCORES_PATH / "musicscores_m{:03d}.db".format(live_data["live_id"])) as score_conn:
+                try:
+                    score = score_conn.execute_and_fetchone(
+                        """
+                        SELECT * FROM blobs WHERE name LIKE "musicscores/m{:03d}/{:d}_{:d}.csv"
+                        """.format(live_data["live_id"], live_data["live_id"], live_data["diff"])
+                    )[1]
+                except TypeError:
+                    logger.debug(
+                        "Cannot find chart for live detail ID {} difficulty {}".format(ldid, live_data["diff"]))
+                    continue
+
+            notes_data = pd.read_csv(StringIO(score.decode()))
+            live_data["duration"] = notes_data.iloc[-1]['sec']
+            notes_data = notes_data[notes_data["type"] < 10].reset_index(drop=True)
+            note_types = notes_data.apply(classify_note, axis=1)
+            note_types_vectorized = classify_note_vectorized(notes_data)
+            self.assertTrue((note_types == note_types_vectorized).all(),
+                            msg=f'Failed for ldid={ldid} (live_id={live_data["live_id"]}, diff={live_data["diff"]}')
+


### PR DESCRIPTION
Add timer uptime data to the GUI. This can be toggled by shift+right click, disabled by default. 

If updating, data/db needs to be deleted. 

To accommodate this change, the remote cache is no longer used. However, optimisations have been made to calculate the note count of types faster. 