### PR TITLE
Minor Fixes for Compatibility

### DIFF
--- a/src/logic/live.py
+++ b/src/logic/live.py
@@ -38,9 +38,10 @@ def classify_note(row):
 
 
 def classify_note_vectorized(row):
-    return np.choose(row.type - 3, [
+    rowtype = row.type.astype(np.int32) # to prevent crashing in 32-bit python
+    return np.choose(rowtype - 3, [
         np.choose(row.status == 0, [NoteType.FLICK, np.choose(
-            row.type - 1, [NoteType.TAP, NoteType.LONG, NoteType.SLIDE], mode="clip")]),
+            rowtype - 1, [NoteType.TAP, NoteType.LONG, NoteType.SLIDE], mode="clip")]),
         NoteType.TAP, NoteType.SLIDE, NoteType.FLICK, NoteType.FLICK], mode="clip")
 
 


### PR DESCRIPTION
Prevent crashing numpy for those running the .py in 32-bit python on their own when updating charts.
(dtype('int64') has been used as the parameter a in np.choose, which may cause unexpected errors in current numpy version)

(The last PR is closed due to merging with my own branch.)